### PR TITLE
Fixed predict route error in return statement

### DIFF
--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -30,4 +30,4 @@ def configure_routes(app):
         })
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)
-        return jsonify(np.asscalar(prediction))
+        return jsonify(np.ndarray.item(prediction))


### PR DESCRIPTION
Resolves #1 

Changed the return statement in predict() in routes.py so that the /predict route brings the user to an output of 0 or 1 instead of 500 Internal Server Error.